### PR TITLE
Remove envs

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -2,3 +2,4 @@ BACKEND_API_URL=address
 ZLEVATOR_URL=address
 APP_SELF_PORT=port
 APP_SELF_HOST=address
+BTC_NETWORK=network

--- a/package-lock.json
+++ b/package-lock.json
@@ -5552,9 +5552,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
       "version": "1.3.0",
@@ -5874,9 +5874,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
-          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -6776,8 +6776,8 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sakiewka-crypto": {
-      "version": "github:softwaremill/sakiewka-crypto#743ed1a2d6da7fc6982b58faaee1c07c860ca5e8",
-      "from": "github:softwaremill/sakiewka-crypto#743ed1a2d6da7fc6982b58faaee1c07c860ca5e8",
+      "version": "github:softwaremill/sakiewka-crypto#a2fbb038db985c92ff2bba3fc969adad0f86349b",
+      "from": "github:softwaremill/sakiewka-crypto#a2fbb03",
       "requires": {
         "@types/bitcoinjs-lib": "3.4.0",
         "@types/chai": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test-coverage": "jest --forceExit --coverage --verbose",
     "test-single-currency": "jest --forceExit --verbose false --detectOpenHandles",
-    "test": "NODE_ENV=test CURRENCY_UNDER_TEST=BTC npm run test-single-currency && NODE_ENV=test CURRENCY_UNDER_TEST=BTG npm run test-single-currency",
+    "test": "NODE_ENV=test CURRENCY_UNDER_TEST=BTC BTC_NETWORK=mainnet npm run test-single-currency && NODE_ENV=test CURRENCY_UNDER_TEST=BTG BTC_NETWORK=mainnet npm run test-single-currency",
     "watch-test": "npm run test -- --watchAll",
     "build": "tsc && npm run swagger",
     "swagger": "cp src/api/swagger.yml dist/api/swagger.yml",
@@ -58,7 +58,7 @@
     "express": "4.16.4",
     "joi": "13.7.0",
     "node-fetch": "2.3.0",
-    "sakiewka-crypto": "github:softwaremill/sakiewka-crypto#743ed1a2d6da7fc6982b58faaee1c07c860ca5e8",
+    "sakiewka-crypto": "github:softwaremill/sakiewka-crypto#a2fbb03",
     "swagger-ui-express": "4.0.1",
     "winston": "^3.1.0",
     "yamljs": "0.3.0"

--- a/src/api/handlers/btc/create-address.ts
+++ b/src/api/handlers/btc/create-address.ts
@@ -3,12 +3,10 @@ import { Request, Response } from 'express'
 import { errorResponse, jsonResponse } from '../../response'
 import { createNewAddressRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto, { Currency } from 'sakiewka-crypto'
+import { Currency, constants } from 'sakiewka-crypto'
 
-const createNewAddress = (currency: Currency) => async (req: Request, res: Response) => {
-  const { address } = sakiewkaCrypto[currency]
-  const { constants } = sakiewkaCrypto
-
+const createNewAddress = (sakiewkaApi, currency: Currency) => async (req: Request, res: Response) => {
+  const { address } = sakiewkaApi[currency]
   const { errors, body } = validate(req, createNewAddressRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/create-key.ts
+++ b/src/api/handlers/btc/create-key.ts
@@ -1,14 +1,12 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto , {Currency} from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { jsonResponse, errorResponse } from '../../response'
 import { createKeyRequest } from '../../models'
 import validate from '../../validate'
 
-const createKey = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
-  const { key } = sakiewkaCrypto[currency]
-
+const createKey = (sakiewkaModule) => async (req: Request, res: Response) => {
+  const { key } = sakiewkaModule
   const { errors, body } = validate(req, createKeyRequest)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/create-wallet.ts
+++ b/src/api/handlers/btc/create-wallet.ts
@@ -1,16 +1,12 @@
 import { Request, Response } from 'express'
-
-import sakiewkaCrypto, { Currency } from 'sakiewka-crypto'
-
+import { Currency, constants } from 'sakiewka-crypto'
 import { errorResponse, jsonResponse } from '../../response'
 import { createWalletRequest } from '../../models'
 import validate from '../../validate'
 
 
-const crateWallet = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
+const crateWallet = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { wallet } = sakiewkaCrypto[currency];
-
   const { errors, body } = validate(req, createWalletRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/get-address.ts
+++ b/src/api/handlers/btc/get-address.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
-
-import sakiewkaCrypto , {Currency} from 'sakiewka-crypto'
+import { Currency, constants } from 'sakiewka-crypto'
 import { jsonResponse, errorResponse } from '../../response'
 import { getAddressRequest } from '../../models'
 import validate from '../../validate'
 
-const getWallet = (currency: Currency) => async (req: Request, res: Response) => {
+const getWallet = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { address } = sakiewkaCrypto[currency]
-  const { constants } = sakiewkaCrypto
   const { errors } = validate(req, getAddressRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/get-balance.ts
+++ b/src/api/handlers/btc/get-balance.ts
@@ -3,10 +3,9 @@ import { Request, Response } from 'express'
 import { jsonResponse, errorResponse } from '../../response'
 import { getBalanceRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto , {Currency} from 'sakiewka-crypto'
+import { Currency, constants } from 'sakiewka-crypto'
 
-const getBalance = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
+const getBalance = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { wallet } = sakiewkaCrypto[currency]
 
   const { errors } = validate(req, getBalanceRequest, true)

--- a/src/api/handlers/btc/get-key.ts
+++ b/src/api/handlers/btc/get-key.ts
@@ -3,12 +3,10 @@ import { Request, Response } from 'express'
 import { jsonResponse, errorResponse } from '../../response'
 import { getKeyRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto , {Currency} from 'sakiewka-crypto'
+import { Currency, constants } from 'sakiewka-crypto'
 
-const getKey = (currency: Currency) => async (req: Request, res: Response) => {
+const getKey = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { key } = sakiewkaCrypto[currency]
-  const { constants } = sakiewkaCrypto
-
   const { errors, queryParams } = validate(req, getKeyRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/get-wallet.ts
+++ b/src/api/handlers/btc/get-wallet.ts
@@ -3,13 +3,11 @@ import { Request, Response } from 'express'
 import { jsonResponse, errorResponse } from '../../response'
 import { getWalletRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto , {Currency} from 'sakiewka-crypto'
+import { Currency, constants } from 'sakiewka-crypto'
 
 
-const getWallet = (currency: Currency) => async (req: Request, res: Response) => {
+const getWallet = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { wallet } = sakiewkaCrypto[currency]
-  const { constants } = sakiewkaCrypto
-
   const { errors } = validate(req, getWalletRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/list-address.ts
+++ b/src/api/handlers/btc/list-address.ts
@@ -3,13 +3,11 @@ import { Request, Response } from 'express'
 import { errorResponse, jsonResponse } from '../../response'
 import { listAddressesRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto, { Currency } from 'sakiewka-crypto'
+import {constants, Currency } from 'sakiewka-crypto'
 
 
-const listAddresses = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
+const listAddresses = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { address } = sakiewkaCrypto[currency]
-
   const { errors, queryParams } = validate(req, listAddressesRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/list-transfers.ts
+++ b/src/api/handlers/btc/list-transfers.ts
@@ -2,19 +2,18 @@ import { Request, Response } from 'express'
 
 import { jsonResponse, errorResponse } from '../../response'
 import { listTransfersRequest } from '../../models'
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import validate from '../../validate'
 
-const { constants, transfers } = sakiewkaCrypto
 
-const listTransfers = async (req: Request, res: Response) => {
+const listTransfers = (sakiewkaApi) => async (req: Request, res: Response) => {
   const { errors, queryParams } = validate(req, listTransfersRequest, true)
 
   if (errors.length > 0) {
     return errorResponse(res, constants.API_ERROR.BAD_REQUEST, errors[0])
   }
 
-  const backendResponse = await transfers.listTransfers(
+  const backendResponse = await sakiewkaApi.transfers.listTransfers(
     req.header('authorization'),
     queryParams.walletId,
     queryParams.limit,

--- a/src/api/handlers/btc/list-utxo.ts
+++ b/src/api/handlers/btc/list-utxo.ts
@@ -3,13 +3,11 @@ import { Request, Response } from 'express'
 import { jsonResponse, errorResponse } from '../../response'
 import { listUtxoRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto , {Currency} from 'sakiewka-crypto'
+import { Currency, constants } from 'sakiewka-crypto'
 
 
-const listUtxo = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
+const listUtxo = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { wallet } = sakiewkaCrypto[currency]
-
   const { errors, body } = validate(req, listUtxoRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/list-wallet.ts
+++ b/src/api/handlers/btc/list-wallet.ts
@@ -3,12 +3,10 @@ import { Request, Response } from 'express'
 import { errorResponse, jsonResponse } from '../../response'
 import { listWalletsRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto, { Currency } from 'sakiewka-crypto'
+import { constants, Currency } from 'sakiewka-crypto'
 
-const listWallets = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
+const listWallets = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { wallet } = sakiewkaCrypto[currency]
-
   const { errors, queryParams } = validate(req, listWalletsRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/max-transfer-amount.ts
+++ b/src/api/handlers/btc/max-transfer-amount.ts
@@ -3,13 +3,10 @@ import { Request, Response } from 'express'
 import { jsonResponse, errorResponse } from '../../response'
 import { maxTransferAmountRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto, { Currency } from 'sakiewka-crypto'
+import { constants, Currency } from 'sakiewka-crypto'
 
-
-const maxTransferAmount = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
+const maxTransferAmount = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { wallet } = sakiewkaCrypto[currency]
-
   const { errors, queryParams } = validate(req, maxTransferAmountRequest, true)
 
   if (errors.length > 0) {

--- a/src/api/handlers/btc/monthly-summary.ts
+++ b/src/api/handlers/btc/monthly-summary.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { jsonResponse, errorResponse } from '../../response'
 import { monthlySummaryRequest } from '../../models'
 import validate from '../../validate'
 
-const { transfers, constants } = sakiewkaCrypto
-
-export default async (req: Request, res: Response) => {
+export const monthlySummary = (sakiewkaApi) => async (req: Request, res: Response) => {
   const { errors } = validate(req, monthlySummaryRequest, true)
 
   if (errors.length > 0) {
@@ -15,7 +13,7 @@ export default async (req: Request, res: Response) => {
   }
 
   const token = req.header('authorization')
-  const backendResponse = await transfers.monthlySummary(token,req.params.month,req.params.year,req.params.fiatCurrency)
+  const backendResponse = await sakiewkaApi.transfers.monthlySummary(token, req.params.month, req.params.year, req.params.fiatCurrency)
 
   jsonResponse(res, backendResponse)
 }

--- a/src/api/handlers/btc/send.ts
+++ b/src/api/handlers/btc/send.ts
@@ -3,11 +3,10 @@ import { Request, Response } from 'express'
 import { jsonResponse, errorResponse } from '../../response'
 import { sendTransactionRequest } from '../../models'
 import validate from '../../validate'
-import sakiewkaCrypto , {Currency} from 'sakiewka-crypto'
+import { Currency, constants } from 'sakiewka-crypto'
 
 
-const sendCoins = (currency: Currency) => async (req: Request, res: Response) => {
-  const { constants } = sakiewkaCrypto
+const sendCoins = (sakiewkaCrypto, currency: Currency) => async (req: Request, res: Response) => {
   const { transaction } = sakiewkaCrypto[currency]
 
   const { errors, body } = validate(req, sendTransactionRequest, true)

--- a/src/api/handlers/chain-network-type.ts
+++ b/src/api/handlers/chain-network-type.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express'
+
+import { jsonResponse } from '../response'
+
+const chainNetworkType = (backendApi) => async (req: Request, res: Response) => {
+  const response = await backendApi.core.chainNetworkType()
+
+  jsonResponse(res, response)
+}
+
+export default chainNetworkType

--- a/src/api/handlers/not-found.ts
+++ b/src/api/handlers/not-found.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { errorResponse } from '../response'
 
 const notFound = async (req: Request, res: Response) => {
-  errorResponse(res, sakiewkaCrypto.constants.API_ERROR.NOT_FOUND)
+  errorResponse(res, constants.API_ERROR.NOT_FOUND)
 }
 
 export default notFound

--- a/src/api/handlers/user/confirm2fa.ts
+++ b/src/api/handlers/user/confirm2fa.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { errorResponse, jsonResponse } from '../../response'
 import { confirm2faRequest } from '../../models'
 import validate from '../../validate'
 
-const { constants, user } = sakiewkaCrypto
-
-const confirm2fa = async (req: Request, res: Response) => {
+export const confirm2fa = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors, body } = validate(req, confirm2faRequest)
 
   if (errors.length > 0) {
@@ -16,9 +14,7 @@ const confirm2fa = async (req: Request, res: Response) => {
 
   const { password, code } = body
   const token = req.header('authorization')
-  const backendResponse = await user.confirm2fa(token, password, code)
+  const backendResponse = await sakiewkaCrypto.user.confirm2fa(token, password, code)
 
   jsonResponse(res, backendResponse)
 }
-
-export default confirm2fa

--- a/src/api/handlers/user/disable2fa.ts
+++ b/src/api/handlers/user/disable2fa.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { errorResponse, jsonResponse } from '../../response'
 import { disable2faRequest } from '../../models'
 import validate from '../../validate'
 
-const { constants, user } = sakiewkaCrypto
-
-const disable2fa = async (req: Request, res: Response) => {
+export const disable2fa = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors, body } = validate(req, disable2faRequest)
 
   if (errors.length > 0) {
@@ -16,9 +14,7 @@ const disable2fa = async (req: Request, res: Response) => {
 
   const { password, code } = body
   const token = req.header('authorization')
-  const backendResponse = await user.disable2fa(token, password, code)
+  const backendResponse = await sakiewkaCrypto.user.disable2fa(token, password, code)
 
   jsonResponse(res, backendResponse)
 }
-
-export default disable2fa

--- a/src/api/handlers/user/info.ts
+++ b/src/api/handlers/user/info.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { jsonResponse, errorResponse } from '../../response'
 import { infoRequest } from '../../models'
 import validate from '../../validate'
 
-const { user, constants } = sakiewkaCrypto
-
-const info = async (req: Request, res: Response) => {
+export const info = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors } = validate(req, infoRequest, true)
 
   if (errors.length > 0) {
@@ -15,9 +13,7 @@ const info = async (req: Request, res: Response) => {
   }
 
   const token = req.header('authorization')
-  const backendResponse = await user.info(token)
+  const backendResponse = await sakiewkaCrypto.user.info(token)
 
   jsonResponse(res, backendResponse)
 }
-
-export default info

--- a/src/api/handlers/user/init2fa.ts
+++ b/src/api/handlers/user/init2fa.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { errorResponse, jsonResponse } from '../../response'
 import { init2faRequest } from '../../models'
 import validate from '../../validate'
 
-const { constants, user } = sakiewkaCrypto
-
-const init2fa = async (req: Request, res: Response) => {
+export const init2fa = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors, body } = validate(req, init2faRequest)
 
   if (errors.length > 0) {
@@ -16,9 +14,7 @@ const init2fa = async (req: Request, res: Response) => {
 
   const { password } = body
   const token = req.header('authorization')
-  const backendResponse = await user.init2fa(token, password)
+  const backendResponse = await sakiewkaCrypto.user.init2fa(token, password)
 
   jsonResponse(res, backendResponse)
 }
-
-export default init2fa

--- a/src/api/handlers/user/login.ts
+++ b/src/api/handlers/user/login.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { errorResponse, jsonResponse } from '../../response'
 import { loginRequest } from '../../models'
 import validate from '../../validate'
 
-const { constants, user } = sakiewkaCrypto
-
-const login = async (req: Request, res: Response) => {
+export const login = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors, body } = validate(req, loginRequest)
 
   if (errors.length > 0) {
@@ -15,9 +13,7 @@ const login = async (req: Request, res: Response) => {
   }
 
   const { login, password, code } = body
-  const backendResponse = await user.login(login, password, code)
+  const backendResponse = await sakiewkaCrypto.user.login(login, password, code)
 
   jsonResponse(res, backendResponse)
 }
-
-export default login

--- a/src/api/handlers/user/logout.ts
+++ b/src/api/handlers/user/logout.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { jsonResponse, errorResponse } from '../../response'
 import { logoutRequest } from '../../models'
 import validate from '../../validate'
 
-const { constants } = sakiewkaCrypto
-
-const info = async (req: Request, res: Response) => {
+export const logout = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors } = validate(req, logoutRequest, true)
 
   if (errors.length > 0) {
@@ -16,5 +14,3 @@ const info = async (req: Request, res: Response) => {
 
   jsonResponse(res, {})
 }
-
-export default info

--- a/src/api/handlers/user/register.ts
+++ b/src/api/handlers/user/register.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { registerRequest } from '../../models'
 import { errorResponse, jsonResponse } from '../../response'
 import validate from '../../validate'
 
-const { constants, user } = sakiewkaCrypto
-
-const register = async (req: Request, res: Response) => {
+export const register = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors, body } = validate(req, registerRequest)
 
   if (errors.length > 0) {
@@ -15,9 +13,7 @@ const register = async (req: Request, res: Response) => {
   }
 
   const { login, password } = body
-  const backendResponse = await user.register(login, password)
+  const backendResponse = await sakiewkaCrypto.user.register(login, password)
 
   jsonResponse(res, backendResponse)
 }
-
-export default register

--- a/src/api/handlers/user/setup-password.ts
+++ b/src/api/handlers/user/setup-password.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from 'express'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
 import { jsonResponse, errorResponse } from '../../response'
 import { setupPasswordRequest } from '../../models'
 import validate from '../../validate'
 
-const { user, constants } = sakiewkaCrypto
-
-const setupPassword = async (req: Request, res: Response) => {
+export const setupPassword = (sakiewkaCrypto) => async (req: Request, res: Response) => {
   const { errors, body } = validate(req, setupPasswordRequest, false)
 
   if (errors.length > 0) {
@@ -15,7 +13,7 @@ const setupPassword = async (req: Request, res: Response) => {
   }
   const { password } = body
   const token = req.header('authorization')
-  const backendResponse = await user.setupPassword(token, password)
+  const backendResponse = await sakiewkaCrypto.user.setupPassword(token, password)
 
   jsonResponse(res, backendResponse)
 }

--- a/src/api/tests/404.test.ts
+++ b/src/api/tests/404.test.ts
@@ -2,8 +2,7 @@ import { expect } from 'chai'
 import app from '../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
-const { constants } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
 
 describe('404', () => {
   it('should properly handle wrong path', async () => {

--- a/src/api/tests/btc/create-address.test.ts
+++ b/src/api/tests/btc/create-address.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { address } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { address } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/create-key.test.ts
+++ b/src/api/tests/btc/create-key.test.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
-
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { key } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { key } = app[currency].cryptoModule
 
 // @ts-ignore
 const mockFnGenerate = jest.fn(() => {

--- a/src/api/tests/btc/create-wallet.test.ts
+++ b/src/api/tests/btc/create-wallet.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { wallet } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { wallet } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/get-address.test.ts
+++ b/src/api/tests/btc/get-address.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { address } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { address } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/get-balance.test.ts
+++ b/src/api/tests/btc/get-balance.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { wallet } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { wallet } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/get-key.test.ts
+++ b/src/api/tests/btc/get-key.test.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
-
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { key } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { key } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/get-wallet.test.ts
+++ b/src/api/tests/btc/get-wallet.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { wallet } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { wallet } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/list-address.test.ts
+++ b/src/api/tests/btc/list-address.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { address } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { address } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/list-transfers.test.ts
+++ b/src/api/tests/btc/list-transfers.test.ts
@@ -2,8 +2,9 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
-const { constants, transfers } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { transfers } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/list-utxo.test.ts
+++ b/src/api/tests/btc/list-utxo.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { wallet } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { wallet } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/list-wallet.test.ts
+++ b/src/api/tests/btc/list-wallet.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { wallet } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { wallet } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/max-transfer-amount.test.ts
+++ b/src/api/tests/btc/max-transfer-amount.test.ts
@@ -2,10 +2,11 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { wallet } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { wallet } = app.sakiewkaApi[currency]
+
 // @ts-ignore
 const mockFn = jest.fn(() => {
   return new Promise((resolve: Function) => {

--- a/src/api/tests/btc/monthly-summary.test.ts
+++ b/src/api/tests/btc/monthly-summary.test.ts
@@ -2,8 +2,9 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
-const { constants, transfers } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { transfers } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/btc/send.test.ts
+++ b/src/api/tests/btc/send.test.ts
@@ -3,10 +3,10 @@ import app from '../../app'
 import supertest from 'supertest'
 import { BigNumber } from "bignumber.js";
 
-import sakiewkaCrypto from 'sakiewka-crypto'
 import { currency } from '../helpers'
-const { constants } = sakiewkaCrypto
-const { transaction } = sakiewkaCrypto[currency]
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { transaction } = app.sakiewkaApi[currency]
 
 // @ts-ignore
 const mockFn = jest.fn(() => {
@@ -47,7 +47,7 @@ describe(`/${currency}/wallet/walletId/send-coins`, () => {
 
   it('should send btc using xprv', async () => {
     const token = 'testToken'
-    const recipients = [{address: 'abcd', amount: '0.00000123'}]
+    const recipients = [{ address: 'abcd', amount: '0.00000123' }]
 
     const response = await supertest(app)
       .post(`/${constants.BASE_API_PATH}/${currency}/wallet/221/send`)
@@ -59,19 +59,19 @@ describe(`/${currency}/wallet/walletId/send-coins`, () => {
 
     const callArgs = mockFn.mock.calls[0]
 
-    expect(response.status).to.be.equal(200,response.text)
+    expect(response.status).to.be.equal(200, response.text)
     const data = response.body.data
     expect(data).to.eq('coins sent')
     expect(callArgs[0]).to.eq(`Bearer ${token}`)
     expect(callArgs[1]).to.eq('221')
-    expect(callArgs[2][0]).to.eql({address: 'abcd', amount: new BigNumber('0.00000123')})
+    expect(callArgs[2][0]).to.eql({ address: 'abcd', amount: new BigNumber('0.00000123') })
     expect(callArgs[3]).to.eq('abc')
     expect(callArgs[4]).to.be.undefined
   })
 
   it('should send btc using passphrase', async () => {
     const token = 'testToken'
-    const recipients = [{address: 'abcd', amount: new BigNumber('0.00000123')}]
+    const recipients = [{ address: 'abcd', amount: new BigNumber('0.00000123') }]
 
     const response = await supertest(app)
       .post(`/${constants.BASE_API_PATH}/${currency}/wallet/221/send`)
@@ -83,12 +83,12 @@ describe(`/${currency}/wallet/walletId/send-coins`, () => {
 
     const callArgs = mockFn.mock.calls[0]
 
-    expect(response.status).to.be.equal(200,response.text)
+    expect(response.status).to.be.equal(200, response.text)
     const data = response.body.data
     expect(data).to.eq('coins sent')
     expect(callArgs[0]).to.eq(`Bearer ${token}`)
     expect(callArgs[1]).to.eq('221')
-    expect(callArgs[2][0]).to.eql({address: 'abcd', amount: new BigNumber('0.00000123')})
+    expect(callArgs[2][0]).to.eql({ address: 'abcd', amount: new BigNumber('0.00000123') })
     expect(callArgs[3]).to.eq('abc')
     expect(callArgs[4]).to.be.undefined
   })

--- a/src/api/tests/chain-network-info.test.ts
+++ b/src/api/tests/chain-network-info.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai'
+import app from '../app'
+import supertest from 'supertest'
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { core } = app.backendApi
+
+// @ts-ignore
+const mockFn = jest.fn(() => {
+  return new Promise((resolve: Function) => {
+    resolve('regtest')
+  })
+})
+
+core.chainNetworkType = mockFn
+
+describe('/chain-network-type', () => {
+  beforeEach(() => {
+    mockFn.mockClear()
+  })
+
+  it('should get chain network type', async () => {
+    const response = await supertest(app)
+      .get(`/${constants.BASE_API_PATH}/chain-network-type`)
+      .send()
+
+    expect(response.status).to.be.equal(200)
+    const data = response.body.data
+    expect(data).to.eq('regtest')
+  })
+})

--- a/src/api/tests/errorHandler.test.ts
+++ b/src/api/tests/errorHandler.test.ts
@@ -1,14 +1,14 @@
 import app from '../app'
 import supertest from 'supertest'
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 const chai = require('chai')
 chai.use(require('chai-uuid'))
 const expect = chai.expect
 
 declare var jest: any
-
-const { constants, user } = sakiewkaCrypto
 
 // @ts-ignore
 user.login = jest.fn(() => {

--- a/src/api/tests/user/confirm2fa.test.ts
+++ b/src/api/tests/user/confirm2fa.test.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
-import sakiewkaCrypto from 'sakiewka-crypto'
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
-const { constants, user } = sakiewkaCrypto
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/user/disable2fa.test.ts
+++ b/src/api/tests/user/disable2fa.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
-import sakiewkaCrypto from 'sakiewka-crypto'
-
-const { constants, user } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/user/init2fa.test.ts
+++ b/src/api/tests/user/init2fa.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
-import sakiewkaCrypto from 'sakiewka-crypto'
-
-const { constants, user } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/user/login.test.ts
+++ b/src/api/tests/user/login.test.ts
@@ -3,9 +3,9 @@ import app from '../../app'
 import supertest from 'supertest'
 
 import { randomString } from '../helpers'
-import sakiewkaCrypto from 'sakiewka-crypto'
-
-const { constants, user } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/user/logout.test.ts
+++ b/src/api/tests/user/logout.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
-
-import sakiewkaCrypto from 'sakiewka-crypto'
-const { constants, user } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/user/register.test.ts
+++ b/src/api/tests/user/register.test.ts
@@ -3,9 +3,9 @@ import app from '../../app'
 import supertest from 'supertest'
 
 import { randomString } from '../helpers'
-import sakiewkaCrypto from 'sakiewka-crypto'
-
-const { constants, user } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/user/setup-password.ts
+++ b/src/api/tests/user/setup-password.ts
@@ -2,8 +2,9 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
-const { constants, user, crypto } = sakiewkaCrypto
+import { constants, crypto } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {

--- a/src/api/tests/user/user-info.test.ts
+++ b/src/api/tests/user/user-info.test.ts
@@ -2,8 +2,9 @@ import { expect } from 'chai'
 import app from '../../app'
 import supertest from 'supertest'
 
-import sakiewkaCrypto from 'sakiewka-crypto'
-const { constants, user } = sakiewkaCrypto
+import { constants } from 'sakiewka-crypto'
+// @ts-ignore
+const { user } = app.sakiewkaApi
 
 // @ts-ignore
 const mockFn = jest.fn(() => {


### PR DESCRIPTION
Na ten moment sakiewka-crypto-local dalej korzysta ze zmiennej `BTC_NETWORK`.

Wynika to z faktu, że nie umiałem w ładny sposób zamockować tego wywołania (dzieje się bardzo wcześnie) oraz z tego że to nie jest wielki problem że tutaj tak będzie. A mamy endpoint który pozwala nam co najwyżej sprawdzić czy to co ustawiliśmy jest ok.