### PR TITLE
Reduce docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,8 @@ WORKDIR /usr/src/app
 # where available (npm@5+)
 COPY package*.json ./
 
-RUN apk add --update alpine-sdk
-RUN apk add --update python
+RUN apk add --no-cache make gcc g++ python git
 RUN npm ci --only=production
-# If you are building your code for production
-# RUN npm ci --only=production
 
 # Bundle app source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:10-alpine
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -8,7 +8,9 @@ WORKDIR /usr/src/app
 # where available (npm@5+)
 COPY package*.json ./
 
-RUN npm ci
+RUN apk add --update alpine-sdk
+RUN apk add --update python
+RUN npm ci --only=production
 # If you are building your code for production
 # RUN npm ci --only=production
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
       "src/**/*"
   ],
   "exclude": [
-      "src/tests/**/*"
+    "src/api/tests/**/*"
   ]
 }


### PR DESCRIPTION
Use `alpine` node image and install only `production` dependencies on docker image.

```
➜  sakiewka-crypto-local git:(reduce-docker-image) ✗ d images | gr sakiewka-crypto-local
sakiewka-crypto-local                           latest                 a59d911a27a7        12 minutes ago      399MB
softwaremill/sakiewka-crypto-local              latest                 1bc20a899d5a        10 days ago         1.07GB
```

Based on this story:
https://antonfisher.com/posts/2018/03/19/reducing-docker-image-size-of-a-node-js-application/